### PR TITLE
Fix scroll up.

### DIFF
--- a/coaster2017/views/sections/footer.blade.php
+++ b/coaster2017/views/sections/footer.blade.php
@@ -49,7 +49,7 @@
 
         $("#scrollbutton2").click(function() {
             $('html, body').animate({
-                scrollTop: $("#top").offset().top
+                scrollTop: 0
             }, 1000);
         });
 


### PR DESCRIPTION
When I currently click on the "Back to the Top" button in the footer of the page, nothing happens, except for an error which is thrown in the console.

![image](https://user-images.githubusercontent.com/10154100/33072511-25651f06-cec0-11e7-8214-0136875f9056.png)
![image](https://user-images.githubusercontent.com/10154100/33072532-3b165270-cec0-11e7-9f30-7ed6d2d08906.png)

I am not sure why the body does not have the id of `top` as it is clearly applied in `themes/coaster2017/sections/head.blade.php` but I think it would be safer to not rely on any id for scrolling up.

That's why I replaced the code responsible for scrolling up with `scrollTop: 0`.

 Best Regards,

